### PR TITLE
fix:SP-1653-self-signed-certificates-grpc-gateway

### DIFF
--- a/pkg/grpc/gateway/gateway.go
+++ b/pkg/grpc/gateway/gateway.go
@@ -24,6 +24,7 @@
 package gateway
 
 import (
+	"crypto/tls"
 	"fmt"
 	"net/http"
 	"strings"
@@ -39,8 +40,8 @@ import (
 )
 
 // SetupGateway configures.
-func SetupGateway(grpcPort, httpPort, tlsCertFile string, allowedIPs, deniedIPs []string,
-	blockByDefault, trustProxy, startTLS bool) (*http.Server, *runtime.ServeMux, string, []grpc.DialOption, error) {
+func SetupGateway(grpcPort, httpPort, tlsCertFile, tlsKeyFile string, allowedIPs, deniedIPs []string,
+	blockByDefault, trustProxy, startTLS bool, insecureSkipVerify bool) (*http.Server, *runtime.ServeMux, string, []grpc.DialOption, error) {
 	httpPort = utils.SetupPort(httpPort)
 	mux := runtime.NewServeMux()
 	srv := &http.Server{
@@ -48,6 +49,9 @@ func SetupGateway(grpcPort, httpPort, tlsCertFile string, allowedIPs, deniedIPs 
 		ReadTimeout:       10 * time.Second,
 		ReadHeaderTimeout: 10 * time.Second,
 		Handler:           mux,
+		TLSConfig: &tls.Config{
+			InsecureSkipVerify: insecureSkipVerify,
+		},
 	}
 	if len(allowedIPs) > 0 || len(deniedIPs) > 0 { // Configure the list of allowed/denied IPs to connect
 		zlog.S.Debugf("Filtering requests by allowed: %v, denied: %v, block-by-default: %v, trust-proxy: %v",
@@ -58,13 +62,29 @@ func SetupGateway(grpcPort, httpPort, tlsCertFile string, allowedIPs, deniedIPs 
 		srv.Handler = handler // assign the filtered handler
 	}
 	var opts []grpc.DialOption
+
 	if startTLS {
-		creds, err := credentials.NewClientTLSFromFile(tlsCertFile, "")
+		var cred credentials.TransportCredentials
+		var err error
+		cred, err = credentials.NewClientTLSFromFile(tlsCertFile, "")
 		if err != nil {
 			zlog.S.Errorf("Problem loading TLS file: %s - %v", tlsCertFile, err)
 			return nil, nil, "", nil, fmt.Errorf("failed to load TLS credentials from file")
 		}
-		opts = []grpc.DialOption{grpc.WithTransportCredentials(creds)}
+
+		if insecureSkipVerify == true {
+			cert, err := tls.LoadX509KeyPair(tlsCertFile, tlsKeyFile)
+			if err != nil {
+				return nil, nil, "", nil, fmt.Errorf("failed to load TLS certificate and key: %v", err)
+			}
+			// Create custom TLS config that skips hostname validation
+			config := &tls.Config{
+				InsecureSkipVerify: true,
+				Certificates:       []tls.Certificate{cert},
+			}
+			cred = credentials.NewTLS(config)
+		}
+		opts = []grpc.DialOption{grpc.WithTransportCredentials(cred)}
 	} else {
 		opts = []grpc.DialOption{grpc.WithTransportCredentials(insecure.NewCredentials())}
 	}


### PR DESCRIPTION
### WHAT

* Allow to ignore host name inconsistencies on self-signed certificates