### PR TITLE
fix: SP-1653 allow change CN on gRPC Gateway

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Upcoming changes...
 
+
+## [0.7.0] - 2024-12-05
+### Added
+- Support for configuring custom CommonName (CN) values in TLS certificates, enabling more flexible certificate management and custom domain setups
+
 ## [0.6.0] - 2024-08-08
 ### Added
 - Added 'sqlite' DB query string

--- a/pkg/grpc/gateway/gateway.go
+++ b/pkg/grpc/gateway/gateway.go
@@ -39,7 +39,7 @@ import (
 )
 
 // SetupGateway configures.
-func SetupGateway(grpcPort, httpPort, tlsCertFile string, allowedIPs, deniedIPs []string,
+func SetupGateway(grpcPort, httpPort, tlsCertFile, CN string, allowedIPs, deniedIPs []string,
 	blockByDefault, trustProxy, startTLS bool) (*http.Server, *runtime.ServeMux, string, []grpc.DialOption, error) {
 	httpPort = utils.SetupPort(httpPort)
 	mux := runtime.NewServeMux()
@@ -59,7 +59,7 @@ func SetupGateway(grpcPort, httpPort, tlsCertFile string, allowedIPs, deniedIPs 
 	}
 	var opts []grpc.DialOption
 	if startTLS {
-		creds, err := credentials.NewClientTLSFromFile(tlsCertFile, "")
+		creds, err := credentials.NewClientTLSFromFile(tlsCertFile, CN)
 		if err != nil {
 			zlog.S.Errorf("Problem loading TLS file: %s - %v", tlsCertFile, err)
 			return nil, nil, "", nil, fmt.Errorf("failed to load TLS credentials from file")

--- a/pkg/grpc/gateway/gateway_test.go
+++ b/pkg/grpc/gateway/gateway_test.go
@@ -41,7 +41,7 @@ func TestGatewaySetupNoTLS(t *testing.T) {
 	defer zlog.SyncZap()
 	allowedIPs := []string{"127.0.0.1"}
 	deniedIPs := []string{"192.168.0.1"}
-	srv, mux, gateway, opts, err := SetupGateway("9443", "8443", "", allowedIPs, deniedIPs, true, false, false)
+	srv, mux, gateway, opts, err := SetupGateway("9443", "8443", "", "", allowedIPs, deniedIPs, true, false, false)
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
@@ -58,7 +58,7 @@ func TestGatewaySetupTLS(t *testing.T) {
 	defer zlog.SyncZap()
 	allowedIPs := []string{"127.0.0.1"}
 	deniedIPs := []string{"192.168.0.1"}
-	srv, mux, gateway, opts, err := SetupGateway(":9443", "8443", "../../../tests/server.crt", allowedIPs, deniedIPs, true, false, true)
+	srv, mux, gateway, opts, err := SetupGateway(":9443", "8443", "../../../tests/server.crt", "", allowedIPs, deniedIPs, true, false, true)
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}


### PR DESCRIPTION
# WHAT:
* Allow to define custom CN (Common Name) on the HTTP/gRPC gateway 