### PR TITLE
chore(status)SP-4302 deprecate StatusCodeToErrorCode and TooManyContr…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.15.0] - 2026-04-15
+### Added
+- Added `NoInfo` status code (`NO_INFO`) to `ComponentStatus` domain model
+### Deprecated
+- Marked `StatusCodeToErrorCode` as deprecated; use `StatusCode.String()` instead
+- Marked `TooManyContributors` status code as deprecated; moved to SemgrepService
+- Marked `ComponentWithoutInfo` status code as deprecated; use `NoInfo` instead
+
 ## [0.14.0] - 2026-04-13
 ### Added
 - Added `TooManyContributors` status code to `ComponentStatus` domain model
@@ -121,3 +129,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [0.12.0]: https://github.com/scanoss/go-grpc-helper/compare/v0.11.0...v0.12.0
 [0.13.0]: https://github.com/scanoss/go-grpc-helper/compare/v0.12.0...v0.13.0
 [0.14.0]: https://github.com/scanoss/go-grpc-helper/compare/v0.13.0...v0.14.0
+[0.15.0]: https://github.com/scanoss/go-grpc-helper/compare/v0.14.0...v0.15.0

--- a/pkg/grpc/domain/component_status.go
+++ b/pkg/grpc/domain/component_status.go
@@ -31,8 +31,8 @@ import (
 // ComponentStatus represents the result status of a component operation,
 // containing a human-readable message and a machine-readable status code.
 type ComponentStatus struct {
-	Message    string
-	StatusCode StatusCode
+	Message    string     `json:"status_message"`
+	StatusCode StatusCode `json:"status_code"`
 }
 
 // StatusCode represents the possible outcome codes for a component operation.
@@ -44,21 +44,30 @@ const (
 	// InvalidPurl indicates the provided PURL is malformed or invalid.
 	InvalidPurl StatusCode = "INVALID_PURL"
 	// ComponentWithoutInfo indicates the component exists but has no available information.
+	//
+	// Deprecated: use NoInfo instead.
 	ComponentWithoutInfo StatusCode = "COMPONENT_WITHOUT_INFO"
+	// NoInfo indicates the component exists but has no available information.
+	NoInfo StatusCode = "NO_INFO"
 	// Success indicates the operation completed successfully.
 	Success StatusCode = "SUCCESS"
 	// InvalidSemver indicates the provided semantic version is invalid.
 	InvalidSemver StatusCode = "INVALID_SEMVER"
 	// VersionNotFound indicates the component version was not found.
 	VersionNotFound StatusCode = "VERSION_NOT_FOUND"
+
 	// TooManyContributors indicates a component has too many contributors.
-	TooManyContributors = "TOO_MANY_CONTRIBUTORS"
+	//
+	// Deprecated: moved to SemgrepService.
+	TooManyContributors StatusCode = "TOO_MANY_CONTRIBUTORS"
 )
 
 // StatusCodeToErrorCode maps a domain StatusCode to its corresponding protobuf ErrorCode.
 // Returns nil for Success or any unrecognized status code.
+//
+// Deprecated: use StatusCode.String() and the protobuf ErrorCode values directly.
 func StatusCodeToErrorCode(code StatusCode) *pb.ErrorCode {
-	switch code {
+	switch code { //nolint:exhaustive // deprecated, intentional partial mapping
 	case InvalidPurl:
 		return pb.ErrorCode_INVALID_PURL.Enum()
 	case ComponentNotFound:
@@ -76,4 +85,9 @@ func StatusCodeToErrorCode(code StatusCode) *pb.ErrorCode {
 	default:
 		return nil
 	}
+}
+
+// String returns the string representation of the StatusCode.
+func (s StatusCode) String() string {
+	return string(s)
 }


### PR DESCRIPTION
…ibutors

  Mark StatusCodeToErrorCode and TooManyContributors as deprecated in favor
  of using StatusCode.String() directly. TooManyContributors has moved to
  SemgrepService.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Deprecations**
  * Status code to error code conversion utility deprecated; use status code string method instead.
  * Contributor limit status indicator deprecated and moved to service.

* **Improvements**
  * Improved JSON serialization for status information fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->