### PR TITLE
feat(gateway): add RegisterHealthEndpoint for GET /health liveness (SP-4473)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,5 @@ coverage*.html
 *-result.json
 
 .DS_Store
+
+.idea

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.16.0] - 2026-06-22
+### Added
+- Added `RegisterHealthEndpoint` to register a GET `/health` liveness route on the grpc-gateway mux
+
 ## [0.15.1] - 2026-04-16
 ### Added
 - Added `RequirementNotMet` status code (`REQUIREMENT_NOT_MET`) to `ComponentStatus` domain model

--- a/pkg/grpc/gateway/health.go
+++ b/pkg/grpc/gateway/health.go
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: MIT
+/*
+ * Copyright (c) 2026, SCANOSS
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package gateway
+
+import (
+	"net/http"
+
+	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
+)
+
+// HealthPath is the path served by RegisterHealthEndpoint.
+const HealthPath = "/health"
+
+// RegisterHealthEndpoint registers a GET /health liveness route on the mux.
+// A running gateway answers 200; a dead one refuses the connection.
+func RegisterHealthEndpoint(mux *runtime.ServeMux) error {
+	return mux.HandlePath(http.MethodGet, HealthPath, func(w http.ResponseWriter, _ *http.Request, _ map[string]string) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"status":"ok"}`))
+	})
+}

--- a/pkg/grpc/gateway/health.go
+++ b/pkg/grpc/gateway/health.go
@@ -24,6 +24,7 @@
 package gateway
 
 import (
+	"errors"
 	"net/http"
 
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
@@ -35,6 +36,9 @@ const HealthPath = "/health"
 // RegisterHealthEndpoint registers a GET /health liveness route on the mux.
 // A running gateway answers 200; a dead one refuses the connection.
 func RegisterHealthEndpoint(mux *runtime.ServeMux) error {
+	if mux == nil {
+		return errors.New("gateway mux is nil")
+	}
 	return mux.HandlePath(http.MethodGet, HealthPath, func(w http.ResponseWriter, _ *http.Request, _ map[string]string) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)

--- a/pkg/grpc/gateway/health_test.go
+++ b/pkg/grpc/gateway/health_test.go
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: MIT
+/*
+ * Copyright (c) 2026, SCANOSS
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package gateway
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
+)
+
+func TestRegisterHealthEndpoint(t *testing.T) {
+	mux := runtime.NewServeMux()
+	if err := RegisterHealthEndpoint(mux); err != nil {
+		t.Fatalf("unexpected error registering health endpoint: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, HealthPath, nil)
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected status %d, got %d", http.StatusOK, rec.Code)
+	}
+	if ct := rec.Header().Get("Content-Type"); ct != "application/json" {
+		t.Errorf("expected Content-Type application/json, got %q", ct)
+	}
+	if body := rec.Body.String(); body != `{"status":"ok"}` {
+		t.Errorf("unexpected body: %q", body)
+	}
+}
+
+// GET-only, so it can't be confused with the POST-only Echo RPCs.
+func TestRegisterHealthEndpointRejectsPost(t *testing.T) {
+	mux := runtime.NewServeMux()
+	if err := RegisterHealthEndpoint(mux); err != nil {
+		t.Fatalf("unexpected error registering health endpoint: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, HealthPath, nil)
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code == http.StatusOK {
+		t.Errorf("expected POST /health to not return 200, got %d", rec.Code)
+	}
+}

--- a/pkg/grpc/gateway/health_test.go
+++ b/pkg/grpc/gateway/health_test.go
@@ -52,6 +52,12 @@ func TestRegisterHealthEndpoint(t *testing.T) {
 	}
 }
 
+func TestRegisterHealthEndpointNilMux(t *testing.T) {
+	if err := RegisterHealthEndpoint(nil); err == nil {
+		t.Error("expected an error for a nil mux, got nil")
+	}
+}
+
 // GET-only, so it can't be confused with the POST-only Echo RPCs.
 func TestRegisterHealthEndpointRejectsPost(t *testing.T) {
 	mux := runtime.NewServeMux()


### PR DESCRIPTION
## What
Adds `gw.RegisterHealthEndpoint(mux)` to the gateway package: registers a real **GET /health** liveness route on the grpc-gateway mux. GET-only, returns `200 {"status":"ok"}`.

## Why
Decoration services currently expose no `/health` route — the gateway returns 200 for any path (error-handler quirk), so the G5 Caddy LB can't actively health-check them. This gives a real, GET-only liveness endpoint that services register explicitly after `SetupGateway`.

Parent bug: SP-4472. This is SP-4473. Adoption per service is SP-4474.

## Test
- `TestRegisterHealthEndpoint`: GET /health → 200 + JSON body
- `TestRegisterHealthEndpointRejectsPost`: POST /health → not 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a health check endpoint accessible via GET requests at `/health` that returns service status information in JSON format.

* **Tests**
  * Added comprehensive tests to verify the health endpoint responds correctly to valid requests and rejects unsupported request methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->